### PR TITLE
Adds a link from the logo to the general opensource page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![inventid logo](https://s3-eu-west-1.amazonaws.com/static-inventid-nl/content/img/logo.png)
+[![inventid logo](https://s3-eu-west-1.amazonaws.com/static-inventid-nl/content/img/logo.png)](http://opensource.inventid.nl)
 
 # Tails
 


### PR DESCRIPTION
For the opensource page this looks much better since we have a backlink to our general opensource pages
