### PR TITLE
Return a fresh promise when a fetching an already synced model

### DIFF
--- a/src/collection.coffee
+++ b/src/collection.coffee
@@ -30,8 +30,13 @@ class Tails.Collection extends Backbone.Deferred.Collection
     return url
 
   fetch: ( options = {} ) ->
-    if (@synced or @syncing) and not options.force
-      return @_fetchPromise
+    unless options.force
+      if @syncing
+        return @_fetchPromise
+      else if @synced
+        deferred = Q.defer()
+        deferred.resolve()
+        return deferred.promise
 
     options.dataType ||= @format
     fetchPromise = super options

--- a/src/model.coffee
+++ b/src/model.coffee
@@ -30,8 +30,13 @@ class Tails.Model extends Backbone.Deferred.Model
     return url
 
   fetch: ( options = {} ) ->
-    if (@synced or @syncing) and not options.force
-      return @_fetchPromise
+    unless options.force
+      if @syncing
+        return @_fetchPromise
+      else if @synced
+        deferred = Q.defer()
+        deferred.resolve()
+        return deferred.promise
 
     options.dataType ||= @format
     fetchPromise = super options


### PR DESCRIPTION
This because a model might be initiated as synced, and no promise
is ever created. This breaks as this means we return undefined.
